### PR TITLE
Fix unclickable links

### DIFF
--- a/modernpro-cv.typ
+++ b/modernpro-cv.typ
@@ -162,7 +162,8 @@
 
 // show contact details
 #let display(contacts) = {
-  set text(10pt, fill: headings-colour , weight: "regular", top-edge: "baseline", bottom-edge: "baseline", baseline: 2pt)
+  v(-5pt)
+  set text(10pt, fill: headings-colour, weight: "regular")
   contacts
     .map(contact => {
         if ("link" in contact) {


### PR DESCRIPTION
Currently, the contact information links don't work. `top-edge: "baseline", bottom-edge: "baseline"` essentially removes the conceptual frame around the text, making the contact links unclickable. `baseline: 2pt` also makes the link highlighting appear ugly and misaligned from the text. A similar spacing effect can be achieved with `v(-5pt)`.